### PR TITLE
/feat serviço de geração de protocolo e CRUD de denúncias.

### DIFF
--- a/api/src/auth/decorators/roles.decorator.ts
+++ b/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/api/src/auth/guards/roles.guard.ts
+++ b/api/src/auth/guards/roles.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => user?.roles?.includes(role));
+  }
+}

--- a/api/src/reports/dto/create-report.dto.ts
+++ b/api/src/reports/dto/create-report.dto.ts
@@ -2,8 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEnum,
   IsNotEmpty,
+  IsNumber,
   IsObject,
+  IsOptional,
   IsString,
+  Max,
+  Min,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -11,18 +15,27 @@ import { ReportType } from '../entities/report.entity';
 
 class LocalizacaoDto {
   @ApiProperty({ example: -23.5505 })
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
   latitude: number;
 
   @ApiProperty({ example: -46.6333 })
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
   longitude: number;
 
   @ApiProperty({ example: 'Av. Paulista, 1000', required: false })
+  @IsString()
+  @IsOptional()
   endereco?: string;
 }
 
 export class CreateReportDto {
   @ApiProperty({ enum: ReportType, example: ReportType.ROUBO })
-  @IsEnum(ReportType)
+  @IsEnum(ReportType, { message: 'Tipo de denúncia inválido' })
+  @IsNotEmpty({ message: 'O tipo da denúncia é obrigatório' })
   tipo: ReportType;
 
   @ApiProperty({ type: LocalizacaoDto })
@@ -33,6 +46,6 @@ export class CreateReportDto {
 
   @ApiProperty({ example: 'Descrição detalhada da ocorrência...' })
   @IsString()
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'Os detalhes da denúncia são obrigatórios' })
   detalhes: string;
 }

--- a/api/src/reports/report.module.ts
+++ b/api/src/reports/report.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Report } from './entities/report.entity';
 import { ReportsService } from './reports.service';
 import { ReportsController } from './reports.controller';
+import { ProtocoloService } from './services/protocolo.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Report])],
-  controllers: [ReportsController],
-  providers: [ReportsService],
+  controllers: [ReportsController, ProtocoloService],
+  providers: [ReportsService, ProtocoloService],
+  exports: [ReportsService],
 })
 export class ReportsModule {}

--- a/api/src/reports/reports.controller.ts
+++ b/api/src/reports/reports.controller.ts
@@ -19,13 +19,15 @@ import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dto/create-report.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Report, ReportType } from './entities/report.entity';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
 
 @ApiTags('reports')
-@Controller('reports')
+@Controller()
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
-  @Post()
+  @Post('reports')
   @ApiOperation({ summary: 'Criar uma nova denúncia (anônima)' })
   @ApiResponse({
     status: 201,
@@ -36,7 +38,7 @@ export class ReportsController {
     return this.reportsService.create(createReportDto);
   }
 
-  @Post('auth')
+  @Post('reports/auth')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Criar uma nova denúncia (autenticada)' })
@@ -52,7 +54,7 @@ export class ReportsController {
     return this.reportsService.create(createReportDto, req.user.id);
   }
 
-  @Get('protocolo/:protocolo')
+  @Get('reports/protocolo/:protocolo')
   @ApiOperation({ summary: 'Buscar denúncia por protocolo' })
   @ApiResponse({
     status: 200,
@@ -64,7 +66,7 @@ export class ReportsController {
     return this.reportsService.findByProtocol(protocolo);
   }
 
-  @Get('minhas-denuncias')
+  @Get('reports/minhas-denuncias')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Listar denúncias do usuário autenticado' })
@@ -77,8 +79,25 @@ export class ReportsController {
     return this.reportsService.findByUserId(req.user.id);
   }
 
-  @Get()
-  @ApiOperation({ summary: 'Listar todas as denúncias' })
+  @Get('admin/reports')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Listar todas as denúncias (acesso administrativo)',
+  })
+  @ApiQuery({ name: 'tipo', enum: ReportType, required: false })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de denúncias',
+    type: [Report],
+  })
+  findAllAdmin(@Query('tipo') tipo?: ReportType): Promise<Report[]> {
+    return this.reportsService.findAll(tipo);
+  }
+
+  @Get('reports')
+  @ApiOperation({ summary: 'Listar denúncias públicas' })
   @ApiQuery({ name: 'tipo', enum: ReportType, required: false })
   @ApiResponse({
     status: 200,

--- a/api/src/reports/reports.service.ts
+++ b/api/src/reports/reports.service.ts
@@ -3,13 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Report, ReportType } from './entities/report.entity';
 import { CreateReportDto } from './dto/create-report.dto';
-import { v4 as uuidv4 } from 'uuid';
+import { ProtocoloService } from './services/protocolo.service';
 
 @Injectable()
 export class ReportsService {
   constructor(
     @InjectRepository(Report)
     private reportsRepository: Repository<Report>,
+    private protocoloService: ProtocoloService,
   ) {}
 
   async create(
@@ -18,7 +19,7 @@ export class ReportsService {
   ): Promise<Report> {
     const report = this.reportsRepository.create({
       ...createReportDto,
-      protocolo: `DEN-${uuidv4().substring(0, 8).toUpperCase()}`,
+      protocolo: this.protocoloService.gerarProtocolo(),
       user: userId ? { id: userId } : null,
     });
 
@@ -33,6 +34,10 @@ export class ReportsService {
   }
 
   async findByProtocol(protocolo: string): Promise<Report> {
+    if (!this.protocoloService.validarProtocolo(protocolo)) {
+      throw new NotFoundException('Formato de protocolo inválido');
+    }
+
     const report = await this.reportsRepository.findOne({
       where: { protocolo },
     });

--- a/api/src/reports/services/protocolo.service.ts
+++ b/api/src/reports/services/protocolo.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class ProtocoloService {
+  /**
+   * Gera um protocolo único para denúncias no formato 'DEN-XXXXXXXX'
+   * onde X são caracteres alfanuméricos
+   */
+  gerarProtocolo(): string {
+    // Formato: DEN- seguido por 8 caracteres do UUID em maiúsculas
+    return `DEN-${uuidv4().substring(0, 8).toUpperCase()}`;
+  }
+
+  /**
+   * Valida se um formato de protocolo é válido
+   */
+  validarProtocolo(protocolo: string): boolean {
+    // Verifica se o protocolo segue o formato DEN-XXXXXXXX (8 caracteres após DEN-)
+    const regex = /^DEN-[A-Z0-9]{8}$/;
+    return regex.test(protocolo);
+  }
+}

--- a/api/src/reports/services/protocolo.services.spec.ts
+++ b/api/src/reports/services/protocolo.services.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProtocoloService } from './protocolo.service';
+
+describe('ProtocoloService', () => {
+  let service: ProtocoloService;
+
+  // Esta função é executada antes de cada teste
+  beforeEach(async () => {
+    // Configura um módulo de teste com o ProtocoloService
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProtocoloService],
+    }).compile();
+
+    // Obtém a instância do serviço do módulo de teste
+    service = module.get<ProtocoloService>(ProtocoloService);
+  });
+
+  // Teste básico para garantir que o serviço foi instanciado corretamente
+  it('deve ser definido', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Grupo de testes para o método gerarProtocolo
+  describe('gerarProtocolo', () => {
+    it('deve gerar um protocolo no formato DEN-XXXXXXXX', () => {
+      const protocolo = service.gerarProtocolo();
+      // Verifica se o formato segue o padrão usando regex
+      expect(protocolo).toMatch(/^DEN-[A-Z0-9]{8}$/);
+    });
+
+    it('deve gerar protocolos únicos em chamadas consecutivas', () => {
+      const protocolo1 = service.gerarProtocolo();
+      const protocolo2 = service.gerarProtocolo();
+      // Verifica se protocolos gerados são diferentes
+      expect(protocolo1).not.toEqual(protocolo2);
+    });
+  });
+
+  // Grupo de testes para o método validarProtocolo
+  describe('validarProtocolo', () => {
+    it('deve validar protocolos no formato correto', () => {
+      // Testa casos válidos
+      expect(service.validarProtocolo('DEN-ABCD1234')).toBe(true);
+      expect(service.validarProtocolo('DEN-12345678')).toBe(true);
+      expect(service.validarProtocolo('DEN-A1B2C3D4')).toBe(true);
+    });
+
+    it('deve rejeitar protocolos em formato inválido', () => {
+      // Testa casos inválidos
+      expect(service.validarProtocolo('DEN-ABC')).toBe(false); // Muito curto
+      expect(service.validarProtocolo('DENABCD1234')).toBe(false); // Sem hífen
+      expect(service.validarProtocolo('den-ABCD1234')).toBe(false); // Prefixo em minúsculas
+      expect(service.validarProtocolo('DEN-abcd1234')).toBe(false); // Sufixo em minúsculas
+      expect(service.validarProtocolo('DEN-ABCD123#')).toBe(false); // Caractere especial
+      expect(service.validarProtocolo('')).toBe(false); // Vazio
+    });
+  });
+});


### PR DESCRIPTION
- Implementado o serviço que gera um protocolo único ao criar uma denúncia;
- Criado as rotas POST /reports (criação) e GET /admin/reports;
- Usado  DTOs para validação de dados;
- Sanitizado os  inputs para evitar SQL injection;